### PR TITLE
feat: remove unused aspects of automation from the manifest

### DIFF
--- a/functions/sample_function_test.ts
+++ b/functions/sample_function_test.ts
@@ -19,7 +19,8 @@ mf.mock("POST@/api/chat.postMessage", () => {
 
 Deno.test("Sample function test", async () => {
   const inputs = { message: "Hello, World!", user: "U01234567" };
-  const { outputs } = await SampleFunction(createContext({ inputs }));
+  const { outputs, error } = await SampleFunction(createContext({ inputs }));
+  assertEquals(error, undefined);
   assertEquals(outputs?.message, "Hello, World!");
   assertEquals(outputs?.user, "U01234567");
 });

--- a/functions/sample_function_test.ts
+++ b/functions/sample_function_test.ts
@@ -20,12 +20,6 @@ mf.mock("POST@/api/chat.postMessage", () => {
 Deno.test("Sample function test", async () => {
   const inputs = { message: "Hello, World!", user: "U01234567" };
   const { outputs } = await SampleFunction(createContext({ inputs }));
-  await assertEquals(
-    outputs?.message,
-    "Hello, World!",
-  );
-  await assertEquals(
-    outputs?.user,
-    "U01234567",
-  );
+  assertEquals(outputs?.message, "Hello, World!");
+  assertEquals(outputs?.user, "U01234567");
 });

--- a/manifest.ts
+++ b/manifest.ts
@@ -10,7 +10,6 @@ export default Manifest({
   name: "deno-function-template",
   description: "A template for building standalone functions in Slack",
   icon: "assets/default_new_app_icon.png",
-  workflows: [],
   functions: [SampleFunctionDefinition],
   outgoingDomains: [],
   datastores: [],

--- a/manifest.ts
+++ b/manifest.ts
@@ -12,12 +12,9 @@ export default Manifest({
   icon: "assets/default_new_app_icon.png",
   functions: [SampleFunctionDefinition],
   outgoingDomains: [],
-  datastores: [],
   botScopes: [
     "commands",
     "chat:write",
     "chat:write.public",
-    "datastore:read",
-    "datastore:write",
   ],
 });


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

This PR removes `workflows` and attributes related to `datastores` from the manifest while these are not referenced in this template. IMO the [documentation around datastores](https://api.slack.com/automation/datastores#manifest) does a great job with instructions on including it in the manifest if this is wanted!

Tests are also updated to check for no errors and remove `awaits` on asserts.

These changes were discovered in preparation for the TDX minihacks! 💻 🎉 

### Reviewers

These changes don't effect the functionality of the function! Try it yourself if you'd like:

```sh
$ slack create my-app --template slack-samples/deno-function-template --branch feat-remove-boilerplate
$ cd my-app
$ slack run
$ slack deploy

# Clean up your environment
$ slack delete
$ cd .. && rm -rf my-app
```

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)